### PR TITLE
Marks appropriate classes/methods as `public`

### DIFF
--- a/MultiToggleButton.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MultiToggleButton.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ToggleButton.swift
+++ b/ToggleButton.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
-class ToggleButton: UIButton
+public class ToggleButton: UIButton
 {
     /// use only this init, it's 'convenience' only to avoid overriding required inits
-    convenience init(images: [UIImage?], states: [String], colors: [UIColor?] = [], action: ((sender: ToggleButton) -> ())? = nil) {
+    public convenience init(images: [UIImage?], states: [String], colors: [UIColor?] = [], action: ((sender: ToggleButton) -> ())? = nil) {
         self.init(frame: CGRectZero)
         if let image = images.first {
             setImage(image, forState: .Normal)
@@ -26,32 +26,32 @@ class ToggleButton: UIButton
         
         setupCurrentState()
     }
-
-    convenience init(image: UIImage?, states: [String], colors: [UIColor?] = [], action: ((sender: ToggleButton) -> ())? = nil) {
+    
+    internal convenience init(image: UIImage?, states: [String], colors: [UIColor?] = [], action: ((sender: ToggleButton) -> ())? = nil) {
         self.init(images: [image], states: states, colors: colors, action: action)
     }
-
+    
     // MARK: - Manual Control
     
-    func toggle() {
+    public func toggle() {
         currentStateIndex = (currentStateIndex + 1) % states.count
         action?(sender: self)
     }
     
-    var currentStateIndex: Int = 0      { didSet {setupCurrentState()} }
-    var colors: [UIColor?] = []         { didSet {setupCurrentState()} }
-    var images: [UIImage?] = []         { didSet {setupCurrentState()} }
-    var states: [String] = [] {
+    public var currentStateIndex: Int = 0      { didSet {setupCurrentState()} }
+    public var colors: [UIColor?] = []         { didSet {setupCurrentState()} }
+    public var images: [UIImage?] = []         { didSet {setupCurrentState()} }
+    public var states: [String] = [] {
         didSet {
             currentStateIndex %= states.count
             setupCurrentState()
         }
     }
-    var action: ((sender: ToggleButton) -> ())?
+    public var action: ((sender: ToggleButton) -> ())?
     
     // MARK: - Overrides
     
-    override func tintColorDidChange() {
+    public override func tintColorDidChange() {
         if nil == currentColor {
             setTitleColor(tintColor, forState: .Normal)
         }


### PR DESCRIPTION
Should fix ToggleButton-as-CocoaPod not being detected by XCode.
